### PR TITLE
adding GET and HEAD endpoints and fixing missing abort ref

### DIFF
--- a/put.py
+++ b/put.py
@@ -1,5 +1,7 @@
 from flask import Flask
 from flask import request
+from flask import abort
+from flask import send_from_directory
 
 import os
 import shutil
@@ -38,6 +40,10 @@ def upload(path):
     with open(fullpath, 'w') as f:
         shutil.copyfileobj(request.stream, f)
     return 'PUT {0} bytes\n'.format(request.content_length), 200, []
+
+@app.route('/<path:path>', methods=['GET','HEAD',])
+def fetch(path):
+    return send_from_directory(app.config['ASSET_ROOT'], path)
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
Just adding a GET/HEAD endpoint.

You can test by installing as per readme, but here's a quickstart:

```
git clone git@github.com:gamernetwork/putter
cd putter/
virtualenv env --no-site-packages
pip install -r requirements.txt
mkdir ~/tmp/putter
echo 'ASSET_ROOT="/home/brendan/tmp/putter/"' > putter.cfg
PUTTER_SETTINGS=putter.cfg env/bin/python put.py
```

In another session

```
curl -X PUT -T <somefile> http://127.0.0.1:5000/haha/<somefile>
```

You should see:

```
PUT <XXXXX> bytes
```

Test HEAD

```
curl -I http://127.0.0.1:5000/haha/<somefile>
```

You should get this sort of thing

```
HTTP/1.0 200 OK
Content-Length: <XXXXX> bytes
Content-Type: image/jpeg
Last-Modified: Tue, 27 Jun 2017 08:41:08 GMT
Cache-Control: public, max-age=43200
Expires: Tue, 27 Jun 2017 20:41:08 GMT
ETag: "flask-1498552868.33-2166498-399379731"
Date: Tue, 27 Jun 2017 08:41:08 GMT
Accept-Ranges: none
Server: Werkzeug/0.12.2 Python/2.7.13
```

Check the bytes match.
